### PR TITLE
Allow for squashing of command line options together

### DIFF
--- a/abduco.c
+++ b/abduco.c
@@ -620,7 +620,6 @@ int main(int argc, char *argv[]) {
 	case 'n':
 	case 'c':
 		if (force) {
-			fprintf(stderr, "Force!");
 			if (session_alive(server.session_name)) {
 				info("session exists and has not yet terminated");
 				return 1;

--- a/abduco.c
+++ b/abduco.c
@@ -562,32 +562,35 @@ int main(int argc, char *argv[]) {
 		}
 		if (server.session_name)
 			usage();
-		switch (argv[arg][1]) {
-		case 'a':
-		case 'A':
-		case 'c':
-		case 'n':
-			action = argv[arg][1];
-			break;
-		case 'e':
-			if (arg + 1 >= argc)
+		int c = 0;
+		while(argv[arg][++c]) {
+			switch (argv[arg][c]) {
+			case 'a':
+			case 'A':
+			case 'c':
+			case 'n':
+				action = argv[arg][c];
+				break;
+			case 'e':
+				if (arg + 1 >= argc)
+					usage();
+				char *esc = argv[++arg];
+				if (esc[0] == '^' && esc[1])
+					*esc = CTRL(esc[1]);
+				KEY_DETACH = *esc;
+				break;
+			case 'f':
+				force = true;
+				break;
+			case 'r':
+				client.readonly = true;
+				break;
+			case 'v':
+				puts("abduco-"VERSION" © 2013-2015 Marc André Tanner");
+				exit(EXIT_SUCCESS);
+			default:
 				usage();
-			char *esc = argv[++arg];
-			if (esc[0] == '^' && esc[1])
-				*esc = CTRL(esc[1]);
-			KEY_DETACH = *esc;
-			break;
-		case 'f':
-			force = true;
-			break;
-		case 'r':
-			client.readonly = true;
-			break;
-		case 'v':
-			puts("abduco-"VERSION" © 2013-2015 Marc André Tanner");
-			exit(EXIT_SUCCESS);
-		default:
-			usage();
+			}
 		}
 	}
 
@@ -617,6 +620,7 @@ int main(int argc, char *argv[]) {
 	case 'n':
 	case 'c':
 		if (force) {
+			fprintf(stderr, "Force!");
 			if (session_alive(server.session_name)) {
 				info("session exists and has not yet terminated");
 				return 1;


### PR DESCRIPTION
Currently, abduco doesn't allow for flexible things like `abduco -cf foobar baz`, but only the more long-winded `abduco -c -f foobar baz`. I've tweaked the command line argument parser to look at each character in an argument starting with a dash (-).

Hope this is found to be useful.