### PR TITLE
Added -l option to move clients to the bottom of the stack.

### DIFF
--- a/abduco.1
+++ b/abduco.1
@@ -28,6 +28,7 @@ abduco - terminal session manager
 .IR detachkey ]
 .RB [ \-r ]
 .RB [ \-f ]
+.RB [ \-l ]
 .RB \-A
 .RB name
 .RB command
@@ -37,6 +38,7 @@ abduco - terminal session manager
 .RB [ \-e
 .IR detachkey ]
 .RB [ \-r ]
+.RB [ \-l ]
 .RB \-a
 .RB name
 .br
@@ -105,6 +107,9 @@ Try to connect to an existing session, upon failure create said session and atta
 .TP
 .BI \-a
 Attach to an existing session.
+.TP
+.BI \-l
+Attach with the lowest priority, meaning this client will be the last to control the size.
 .SH EXAMPLE
 Start a new session (assuming
 .BR dvtm(1)

--- a/abduco.c
+++ b/abduco.c
@@ -77,7 +77,9 @@ typedef struct {
 		char msg[BUFSIZ];
 		struct winsize ws;
 		int i;
-		bool b;
+		struct {
+			bool ro, lp;
+		} attach;
 	} u;
 } Packet;
 
@@ -114,7 +116,7 @@ typedef struct {
 static Server server = { .running = true, .exit_status = -1, .host = "@localhost" };
 static Client client;
 static struct termios orig_term, cur_term;
-static bool has_term, alternate_buffer;
+static bool has_term, alternate_buffer, low_priority;
 
 static struct sockaddr_un sockaddr = {
 	.sun_family = AF_UNIX,
@@ -582,7 +584,7 @@ int main(int argc, char *argv[]) {
 	if (argc == 1)
 		exit(list_session());
 
-	while ((opt = getopt(argc, argv, "aAcne:frv")) != -1) {
+	while ((opt = getopt(argc, argv, "aAclne:frv")) != -1) {
 		switch (opt) {
 		case 'a':
 		case 'A':
@@ -602,6 +604,9 @@ int main(int argc, char *argv[]) {
 			break;
 		case 'r':
 			client.readonly = true;
+			break;
+		case 'l':
+			low_priority = true;
 			break;
 		case 'v':
 			puts("abduco-"VERSION" © 2013-2015 Marc André Tanner");

--- a/client.c
+++ b/client.c
@@ -62,8 +62,8 @@ static int client_mainloop(void) {
 	client.need_resize = true;
 	Packet pkt = {
 		.type = MSG_ATTACH,
-		.u = { .b = client.readonly },
-		.len = sizeof(pkt.u.b),
+		.u = { .attach = { .ro = client.readonly, .lp = low_priority } },
+		.len = sizeof(pkt.u.attach),
 	};
 	client_send_packet(&pkt);
 


### PR DESCRIPTION
This means it wont take control over the window size until it is the last remaining one, unless another client connects with the `-l` option set at a later time.

I have found this useful in conjunction with `-r` and also when connecting with something that is not a real terminal, e.g. sending input to an abduco session running a REPL from my editor.