### PR TITLE
Fix manual page markup

### DIFF
--- a/abduco.1
+++ b/abduco.1
@@ -93,7 +93,7 @@ Print version information to standard output and exit.
 .B \-r
 Readonly session, i.e. user input is ignored.
 .TP
-.BI \-e \ detachkey
+.B \-e \fIdetachkey\fR
 Set the key to detach which by default is set to CTRL+\\ i.e. ^\\ to detachkey.
 .TP
 .BI \-f


### PR DESCRIPTION
The space between `-e detachkey` was being underlined, when only
`detachkey` should be.

Tested with mandoc from OpenBSD -current and groff 1.22.3, the latter of
which is used by the vast majority of Linux distributions for formatting
manual pages.