### PR TITLE
fix bug where attaching to dead session won't give underlying exit code

### DIFF
--- a/client.c
+++ b/client.c
@@ -63,13 +63,6 @@ static int client_mainloop(void) {
 	sigprocmask(SIG_BLOCK, &blockset, NULL);
 
 	client.need_resize = true;
-	Packet pkt = {
-		.type = MSG_ATTACH,
-		.u.i = client.flags,
-		.len = sizeof(pkt.u.i),
-	};
-	client_send_packet(&pkt);
-
 	while (server.running) {
 		fd_set fds;
 		FD_ZERO(&fds);


### PR DESCRIPTION
If dvtm dies, and you run `:|abduco -a session`, abduco will often exit
without giving you the exit code, and without removing the socket from
~/.abduco.

We resolve this by first sending the client either an EXIT or an empty
CONTENT packet.

Only after the client recieves it, we set the socket to non-blocking.

Fixes: https://github.com/martanne/abduco/issues/44