### PR TITLE
Add -d flag to detect if a session exists

### DIFF
--- a/abduco.1
+++ b/abduco.1
@@ -25,6 +25,10 @@
 .Cm command Op args ...
 .
 .Nm
+.Fl d
+.Cm name
+.
+.Nm
 .Fl n
 .Op options ...
 .Cm name
@@ -84,6 +88,8 @@ Attach to an existing session.
 Try to connect to an existing session, upon failure create said session and attach immediately to it.
 .It Fl c
 Create a new session and attach immediately to it.
+.It Fl d
+Detect if the specified session exists, returning a successful exit status if true.
 .It Fl n
 Create a new session but do not attach to it.
 .El

--- a/abduco.c
+++ b/abduco.c
@@ -606,11 +606,12 @@ int main(int argc, char *argv[]) {
 	server.name = basename(argv[0]);
 	gethostname(server.host+1, sizeof(server.host) - 1);
 
-	while ((opt = getopt(argc, argv, "aAclne:fpqrv")) != -1) {
+	while ((opt = getopt(argc, argv, "aAcdlne:fpqrv")) != -1) {
 		switch (opt) {
 		case 'a':
 		case 'A':
 		case 'c':
+		case 'd':
 		case 'n':
 			action = opt;
 			break;
@@ -712,6 +713,13 @@ int main(int argc, char *argv[]) {
 			goto redo;
 		}
 		break;
+    case 'd':
+        if (session_exists(server.session_name)) {
+            return EXIT_SUCCESS;
+        } else {
+            return EXIT_FAILURE;
+        }
+        break;
 	}
 
 	return 0;


### PR DESCRIPTION
One feature I miss from `tmux` is the ability to detect if a session exists from a shell script. This PR adds a `-d` flag, that checks if a specified session exists, returning a successful exit status if true.