### PR TITLE
Screen buffer

### DIFF
--- a/abduco.c
+++ b/abduco.c
@@ -105,7 +105,6 @@ struct Client {
 typedef struct {
 	Client *clients;
 	int socket;
-	Packet pty_output;
 	int pty;
 	int exit_status;
 	struct termios term;


### PR DESCRIPTION
 When a client attaches to an existing session, the session command output is not available to him. The problem is not noticeable when the program (top, man, etc.) in the session is able to redraw its output.

But this does not work with non-interactive utilities. The output of commands in bash will not be available to the client connecting to the session.

To solve this, we add a buffer that contains the last few lines of the session output. When a new client attaches, the contents of this buffer are sent to him.

This PR could address #57, #32 and maybe more.