### PR TITLE
Added silent reconnect feature

### DIFF
--- a/abduco.1
+++ b/abduco.1
@@ -115,6 +115,9 @@ options.
 Be quiet, do not print informative messages.
 .It Fl r
 Read-only session, user input is ignored.
+.IT F1 s
+Silently Attach/Detach without switching to/from alternate buffer. Useful for automatically reconnecting
+persistent SSH connections that don't want to alter terminal state when reconnecting.
 .It Fl v
 Print version information and exit.
 .El

--- a/abduco.c
+++ b/abduco.c
@@ -98,6 +98,7 @@ struct Client {
 	enum {
 		CLIENT_READONLY = 1 << 0,
 		CLIENT_LOWPRIORITY = 1 << 1,
+    CLIENT_NOALTBUF = 1 << 1,
 	} flags;
 	Client *next;
 };
@@ -223,7 +224,7 @@ static void die(const char *s) {
 }
 
 static void usage(void) {
-	fprintf(stderr, "usage: abduco [-a|-A|-c|-n] [-p] [-r] [-q] [-l] [-f] [-e detachkey] name command\n");
+	fprintf(stderr, "usage: abduco [-a|-A|-c|-n] [-p] [-r] [-q] [-l] [-f] [-s] [-e detachkey] name command\n");
 	exit(EXIT_FAILURE);
 }
 
@@ -633,6 +634,9 @@ int main(int argc, char *argv[]) {
 		case 'r':
 			client.flags |= CLIENT_READONLY;
 			break;
+    case 's':
+      client.flags |= CLIENT_NOALTBUF;
+      break;
 		case 'l':
 			client.flags |= CLIENT_LOWPRIORITY;
 			break;

--- a/client.c
+++ b/client.c
@@ -25,7 +25,7 @@ static void client_restore_terminal(void) {
 	if (!has_term)
 		return;
 	tcsetattr(STDIN_FILENO, TCSAFLUSH, &orig_term);
-	if (alternate_buffer) {
+	if (!(client.flags & CLIENT_NOALTBUF) && alternate_buffer) {
 		printf("\033[?25h\033[?1049l");
 		fflush(stdout);
 		alternate_buffer = false;
@@ -48,7 +48,7 @@ static void client_setup_terminal(void) {
 	cur_term.c_cc[VTIME] = 0;
 	tcsetattr(STDIN_FILENO, TCSANOW, &cur_term);
 
-	if (!alternate_buffer) {
+	if (!(client.flags & CLIENT_NOALTBUF) && !alternate_buffer) {
 		printf("\033[?1049h\033[H");
 		fflush(stdout);
 		alternate_buffer = true;


### PR DESCRIPTION
Hey there! I added a simple feature I've been using for a while that just suppresses automatically switching to/from the alternate buffer on client connect/disconnect.

I do a lot of remote work over SSH with an unreliable internet connection, so I have a simple local script I run to establish a persistent SSH connection which generates a UUID session name based on the current shell's pid, so I can have multiple active connections:

```
while ! ssh -tt $@ -- '~/.local/bin/abduco' -A -s ${SSHP_SESSION:="$(uuidgen --sha1 --namespace @oid --name $$)"} bash -li;
do
  :
done 2>&-
```

By adding this silent feature, when a disconnect happens, followed by a reconnect, nothing is changed in the terminal window, so it is easy to pick up where I left off. 