### PR TITLE
abduco: report pixel sizes to child processes that use ioctl(0, TIOCGWINSZ, ...)

### DIFF
--- a/abduco.c
+++ b/abduco.c
@@ -79,6 +79,8 @@ typedef struct {
 		struct {
 			uint16_t rows;
 			uint16_t cols;
+			uint16_t xpixels;
+			uint16_t ypixels;
 		} ws;
 		uint32_t i;
 		uint64_t l;
@@ -677,6 +679,8 @@ int main(int argc, char *argv[]) {
 	if (ioctl(STDIN_FILENO, TIOCGWINSZ, &server.winsize) == -1) {
 		server.winsize.ws_col = 80;
 		server.winsize.ws_row = 25;
+		server.winsize.ws_xpixel = 640;
+		server.winsize.ws_ypixel = 480;
 	}
 
 	server.read_pty = (action == 'n');

--- a/client.c
+++ b/client.c
@@ -81,7 +81,7 @@ static int client_mainloop(void) {
 			if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) != -1) {
 				Packet pkt = {
 					.type = MSG_RESIZE,
-					.u = { .ws = { .rows = ws.ws_row, .cols = ws.ws_col } },
+					.u = { .ws = { .rows = ws.ws_row, .cols = ws.ws_col, .xpixels = ws.ws_xpixel, .ypixels = ws.ws_ypixel } },
 					.len = sizeof(pkt.u.ws),
 				};
 				if (client_send_packet(&pkt))

--- a/server.c
+++ b/server.c
@@ -234,6 +234,8 @@ static void server_mainloop(void) {
 						struct winsize ws = { 0 };
 						ws.ws_row = client_packet.u.ws.rows;
 						ws.ws_col = client_packet.u.ws.cols;
+						ws.ws_xpixel = client_packet.u.ws.xpixels;
+						ws.ws_ypixel = client_packet.u.ws.ypixels;
 						ioctl(server.pty, TIOCSWINSZ, &ws);
 					}
 					kill(-server.pid, SIGWINCH);


### PR DESCRIPTION
Add the ws_xpixel and ws_ypixel fields to the IPC packets so that abduco can properly respond to ioctl() requests for the screen size.

This enables terminals such as "kitty" to display images inside of an abduco session.