### PR TITLE
man page fix typo in `-p` examples

### DIFF
--- a/abduco.1
+++ b/abduco.1
@@ -206,7 +206,7 @@ as detach key.
 .Pp
 Send a command to an existing session.
 .Pp
-.Dl $ echo make | abduco -a my-session
+.Dl $ echo make | abduco -p my-session
 .Pp
 Or in a slightly more interactive fashion.
 .Pp


### PR DESCRIPTION
Unless I misunderstood the manual, `-a` is wrong here.